### PR TITLE
Update ctc.py

### DIFF
--- a/espnet2/asr/ctc.py
+++ b/espnet2/asr/ctc.py
@@ -23,7 +23,7 @@ class CTC(torch.nn.Module):
         dropout_rate: float = 0.0,
         ctc_type: str = "builtin",
         reduce: bool = True,
-        ignore_nan_grad: bool = False,
+        ignore_nan_grad: bool = True,
     ):
         assert check_argument_types()
         super().__init__()


### PR DESCRIPTION
setting the --ctc_conf ignore_nan_grad= true like @pengchengguo and @sw005320 suggested at [#3290](https://github.com/espnet/espnet/issues/3290)